### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/FyningTime/FyningTime/security/code-scanning/1](https://github.com/FyningTime/FyningTime/security/code-scanning/1)

To fix the problem, add a `permissions` block to limit the GITHUB_TOKEN's privileges. Since none of the steps require write access (they only read code, build, and test), setting `contents: read` is sufficient. You can place the `permissions` block at the root of the workflow (applies to all jobs unless overridden) or inside the `build` job (applies only to that job). In this context, placing it at the root is standard for single-job workflows like this. Edit `.github/workflows/go.yml` immediately after the `name: Go` line, inserting:
```yaml
permissions:
  contents: read
```
No further code or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
